### PR TITLE
Fix/junit mocking corrections all test classes

### DIFF
--- a/src/main/java/com/klodnicki/Bike/v2/DTO/bike/BikeForNormalUserResponseDTO.java
+++ b/src/main/java/com/klodnicki/Bike/v2/DTO/bike/BikeForNormalUserResponseDTO.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Data
 public class BikeForNormalUserResponseDTO {
     private Long id;
     private String serialNumber;

--- a/src/main/java/com/klodnicki/Bike/v2/DTO/rent/RentResponseDTO.java
+++ b/src/main/java/com/klodnicki/Bike/v2/DTO/rent/RentResponseDTO.java
@@ -3,10 +3,7 @@ package com.klodnicki.Bike.v2.DTO.rent;
 import com.klodnicki.Bike.v2.DTO.bike.BikeForNormalUserResponseDTO;
 import com.klodnicki.Bike.v2.DTO.station.StationForNormalUserResponseDTO;
 import com.klodnicki.Bike.v2.DTO.user.UserForNormalUserResponseDTO;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -14,6 +11,7 @@ import java.time.LocalDateTime;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@Data
 public class RentResponseDTO {
 
     private Long id;

--- a/src/main/java/com/klodnicki/Bike/v2/model/RentRequest.java
+++ b/src/main/java/com/klodnicki/Bike/v2/model/RentRequest.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 @Setter
 public class RentRequest {
 
+    private Long id;
     private Long userId;
     private Long bikeId;
     private int daysOfRent;

--- a/src/main/java/com/klodnicki/Bike/v2/model/RentRequest.java
+++ b/src/main/java/com/klodnicki/Bike/v2/model/RentRequest.java
@@ -1,10 +1,14 @@
 package com.klodnicki.Bike.v2.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class RentRequest {
 
     private Long id;

--- a/src/main/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandler.java
+++ b/src/main/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandler.java
@@ -110,8 +110,9 @@ public class RentBikeServiceHandler implements RentBikeServiceApi {
         User user = rent.getUser();
         ChargingStation returnChargingStation = chargingStationService.findStationById(returnChargingStationId);
 
+        double rentalCost = countRentalCost(rentId);
         rent.setRentalEndTime(LocalDateTime.now());
-        rent.setAmountToBePaid(countRentalCost(rentId));
+        rent.setAmountToBePaid(rentalCost);
         rent.setChargingStation(returnChargingStation);
 
         bike.setRented(false);
@@ -122,7 +123,7 @@ public class RentBikeServiceHandler implements RentBikeServiceApi {
 
         returnChargingStation.setFreeSlots(returnChargingStation.getFreeSlots() - 1);
 
-        user.setBalance(user.getBalance() - countRentalCost(rentId)); //reducing the user balance by rental cost
+        user.setBalance(user.getBalance() - rentalCost); //reducing the user balance by rental cost
 
         bikeService.save(bike);
         chargingStationService.save(returnChargingStation);

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -77,22 +77,23 @@ class BikeServiceHandlerTest {
 
     @Test
     public void findAll_ShouldReturnListOfBikeForAdminResponseDTO_WhenBikeExistInDatabase() {
-        //given
-        bikeRepository.deleteAll();
-        ArrayList<BikeForAdminResponseDTO> list = new ArrayList<>();
+        //Arrange
+        List<Bike> bikeList = new ArrayList<>();
+        List<BikeForAdminResponseDTO> bikeListDto = new ArrayList<>();
 
         for (int i = 0; i < 3; i++) {
-            Bike bike = new Bike();
-            bikeRepository.save(bike);
-            BikeForAdminResponseDTO bikeDTO = modelMapper.map(bike, BikeForAdminResponseDTO.class);
-            list.add(bikeDTO);
+            bikeList.add(bike);
+            bikeListDto.add(bikeForAdminResponseDTO);
         }
 
-        //when
+        when(bikeRepository.findAll()).thenReturn(bikeList);
+        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
+
+        //Act
         List<BikeForAdminResponseDTO> actual = bikeServiceHandler.findAll();
 
-        //then
-        assertEquals(list, actual);
+        //Assert
+        assertEquals(bikeListDto, actual);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -20,6 +20,7 @@ import org.modelmapper.ModelMapper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -97,19 +98,16 @@ class BikeServiceHandlerTest {
     }
 
     @Test
-    public void findById_ShouldReturnBikeForAdminResponseDTO_WhenBikeExistsInDatabase() {
-        //given
-        bikeRepository.deleteAll();
-        Bike bike = new Bike();
-        bikeRepository.save(bike);
+    public void findById_ShouldReturnBikeForAdminResponseDTO_WhenBikeExistsInDatabaseAndIdOfBikeIsProvided() {
+        //Arrange
+        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
 
-        BikeForAdminResponseDTO expected = modelMapper.map(bike, BikeForAdminResponseDTO.class);
-
-        //when
+        //Act
         BikeForAdminResponseDTO actual = bikeServiceHandler.findById(bike.getId());
 
         //then
-        assertEquals(expected, actual);
+        assertEquals(bikeForAdminResponseDTO, actual);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -199,18 +199,15 @@ class BikeServiceHandlerTest {
     }
 
     @Test
-    public void save_ShouldSaveInDatabase_WhenGivenBikeObject() {
-        //given
-        bikeRepository.deleteAll();
-        Long expected = bikeRepository.count() + 1;
-        Bike bike = new Bike();
+    public void save_ShouldCallOnRepositoryExactlyOnce_WhenGivenBikeObject() {
+        //Arrange
+        when(bikeRepository.save(bike)).thenReturn(bike);
 
-        //when
+        //Act
         bikeServiceHandler.save(bike);
-        Long actual = bikeRepository.count();
 
-        //then
-        assertEquals(expected, actual);
+        //Assert
+        verify(bikeRepository, times(1)).save(bike);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -48,18 +48,17 @@ class BikeServiceHandlerTest {
     }
 
     @Test
-    public void add_ShouldAddToDatabase_WhenGivenCorrectArguments() {
-        //given
-        bikeRepository.deleteAll();
-        BikeRequestDTO bikeRequestDTO = new BikeRequestDTO();
+    public void add_ShouldCallOnRepositoryExactlyOnce_WhenGivenBikeRequestDTOObject() {
+        //Arrange
+        when(modelMapper.map(bikeRequestDTO, Bike.class)).thenReturn(bike);
+        when(bikeRepository.save(bike)).thenReturn(bike);
+        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
+
+        //Act
         bikeServiceHandler.add(bikeRequestDTO);
-        Long expected = 1L;
 
-        //when
-        Long actual = bikeRepository.count();
-
-        //then
-        assertEquals(expected, actual);
+        //Assert
+        verify(bikeRepository, times(1)).save(bike);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -212,11 +212,6 @@ class BikeServiceHandlerTest {
 
     @Test
     public void findBikeById_ShouldThrowIllegalArgumentException_WhenGivenIdDoesNotExistInDatabase() {
-        //given
-        bikeRepository.deleteAll();
-
-        //when
-        //then
         assertThrows(IllegalArgumentException.class, () -> bikeServiceHandler.findBikeById(1L));
     }
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -176,7 +176,7 @@ class BikeServiceHandlerTest {
     }
 
     @Test
-    public void findByIsRentedFalse_ShouldReturnListOfNotRentedBikes_WhenRentIsFalse() {
+    public void findByIsRentedFalse_ShouldReturnListOfNotRentedBikes_WhenNotRentedBikesAreInDatabase() {
         //Arrange
         List<Bike> expected = new ArrayList<>();
 

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -147,18 +147,19 @@ class BikeServiceHandlerTest {
 
     @Test
     public void update_ShouldReturnEmptyOptional_WhenBikeRequestDTOValuesAreNulls() {
-        //given
-        bikeRepository.deleteAll();
-        Bike bike = new Bike();
-        bikeRepository.save(bike);
-
-        BikeRequestDTO bikeRequestDTO = new BikeRequestDTO(bike.getId(), null, true, null,
+        //Arrange
+        Bike bike = mock(Bike.class);
+        BikeRequestDTO bikeRequestDTO = new BikeRequestDTO(null, null, true, null,
                 100.00, null, new UserForAdminResponseDTO(), new StationForAdminResponseDTO());
 
-        //when
+        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+        when(bikeRepository.save(bike)).thenReturn(bike);
+        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
+
+        //Act
         BikeForAdminResponseDTO actual = bikeServiceHandler.update(bike.getId(), bikeRequestDTO);
 
-        //then
+        //Assert
         assertNull(actual.getSerialNumber());
         assertNull(actual.getBikeType());
         assertNull(actual.getGpsCoordinates());

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -14,29 +14,32 @@ import com.klodnicki.Bike.v2.model.entity.User;
 import com.klodnicki.Bike.v2.repository.BikeRepository;
 import com.klodnicki.Bike.v2.repository.ChargingStationRepository;
 import com.klodnicki.Bike.v2.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
-@SpringBootTest
 class BikeServiceHandlerTest {
 
-    @Autowired
     private BikeRepository bikeRepository;
-    @Autowired
     private ChargingStationRepository chargingStationRepository;
-    @Autowired
     private UserRepository userRepository;
-    @Autowired
     private BikeServiceHandler bikeServiceHandler;
-    @Autowired
     private ModelMapper modelMapper;
+
+    @BeforeEach
+    public void setUp(){
+        bikeRepository = mock(BikeRepository.class);
+        chargingStationRepository = mock(ChargingStationRepository.class);
+        userRepository = mock(UserRepository.class);
+        modelMapper = mock(ModelMapper.class);
+        bikeServiceHandler = new BikeServiceHandler(bikeRepository, modelMapper);
+    }
 
     @Test
     public void add_ShouldAddToDatabase_WhenGivenCorrectArguments() {

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 class BikeServiceHandlerTest {
 
@@ -31,6 +31,9 @@ class BikeServiceHandlerTest {
     private UserRepository userRepository;
     private BikeServiceHandler bikeServiceHandler;
     private ModelMapper modelMapper;
+    private Bike bike;
+    private BikeRequestDTO bikeRequestDTO;
+    private BikeForAdminResponseDTO bikeForAdminResponseDTO;
 
     @BeforeEach
     public void setUp(){
@@ -39,6 +42,9 @@ class BikeServiceHandlerTest {
         userRepository = mock(UserRepository.class);
         modelMapper = mock(ModelMapper.class);
         bikeServiceHandler = new BikeServiceHandler(bikeRepository, modelMapper);
+        bike = mock(Bike.class);
+        bikeRequestDTO = mock(BikeRequestDTO.class);
+        bikeForAdminResponseDTO = mock(BikeForAdminResponseDTO.class);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -166,18 +166,13 @@ class BikeServiceHandlerTest {
     }
 
     @Test
-    public void deleteById_ShouldDeleteFromDatabase_WhenGivenId() {
-        //given
-        bikeRepository.deleteAll();
-        Bike bike = new Bike();
-        bikeRepository.save(bike);
-        Long expected = bikeRepository.count() - 1;
-
-        //when
+    public void deleteById_ShouldCallOnRepositoryExactlyOnce_WhenGivenId() {
+        //Arrange
+        //Act
         bikeServiceHandler.deleteById(bike.getId());
 
         //then
-        assertEquals(expected, bikeRepository.count());
+        verify(bikeRepository, times(1)).deleteById(bike.getId());
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -46,14 +46,16 @@ class BikeServiceHandlerTest {
         bike = mock(Bike.class);
         bikeRequestDTO = mock(BikeRequestDTO.class);
         bikeForAdminResponseDTO = mock(BikeForAdminResponseDTO.class);
+
+        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+        when(bikeRepository.save(bike)).thenReturn(bike);
+        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
     }
 
     @Test
     public void add_ShouldCallOnRepositoryExactlyOnce_WhenGivenBikeRequestDTOObject() {
-        //Arrange
+        //Arrange - takes from @BeforeEach setUp()
         when(modelMapper.map(bikeRequestDTO, Bike.class)).thenReturn(bike);
-        when(bikeRepository.save(bike)).thenReturn(bike);
-        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
 
         //Act
         bikeServiceHandler.add(bikeRequestDTO);
@@ -64,10 +66,8 @@ class BikeServiceHandlerTest {
 
     @Test
     public void add_ShouldReturnBikeForAdminResponseDTO_WhenGivenBikeRequestDTO() {
-        //Arrange
+        //Arrange - takes from @BeforeEach setUp()
         when(modelMapper.map(bikeRequestDTO, Bike.class)).thenReturn(bike);
-        when(bikeRepository.save(bike)).thenReturn(bike);
-        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
 
         //Act
         BikeForAdminResponseDTO actual = bikeServiceHandler.add(bikeRequestDTO);
@@ -78,7 +78,7 @@ class BikeServiceHandlerTest {
 
     @Test
     public void findAll_ShouldReturnListOfBikeForAdminResponseDTO_WhenBikeExistInDatabase() {
-        //Arrange
+        //Arrange - takes from @BeforeEach setUp()
         List<Bike> bikeList = new ArrayList<>();
         List<BikeForAdminResponseDTO> bikeListDto = new ArrayList<>();
 
@@ -88,7 +88,6 @@ class BikeServiceHandlerTest {
         }
 
         when(bikeRepository.findAll()).thenReturn(bikeList);
-        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
 
         //Act
         List<BikeForAdminResponseDTO> actual = bikeServiceHandler.findAll();
@@ -99,10 +98,7 @@ class BikeServiceHandlerTest {
 
     @Test
     public void findById_ShouldReturnBikeForAdminResponseDTO_WhenBikeExistsInDatabaseAndIdOfBikeIsProvided() {
-        //Arrange
-        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
-        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
-
+        //Arrange - takes from @BeforeEach setUp()
         //Act
         BikeForAdminResponseDTO actual = bikeServiceHandler.findById(bike.getId());
 
@@ -148,13 +144,8 @@ class BikeServiceHandlerTest {
     @Test
     public void update_ShouldReturnEmptyOptional_WhenBikeRequestDTOValuesAreNulls() {
         //Arrange
-        Bike bike = mock(Bike.class);
         BikeRequestDTO bikeRequestDTO = new BikeRequestDTO(null, null, true, null,
                 100.00, null, new UserForAdminResponseDTO(), new StationForAdminResponseDTO());
-
-        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
-        when(bikeRepository.save(bike)).thenReturn(bike);
-        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
 
         //Act
         BikeForAdminResponseDTO actual = bikeServiceHandler.update(bike.getId(), bikeRequestDTO);
@@ -200,9 +191,7 @@ class BikeServiceHandlerTest {
 
     @Test
     public void save_ShouldCallOnRepositoryExactlyOnce_WhenGivenBikeObject() {
-        //Arrange
-        when(bikeRepository.save(bike)).thenReturn(bike);
-
+        //Arrange - takes from @BeforeEach setUp()
         //Act
         bikeServiceHandler.save(bike);
 

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -63,18 +63,16 @@ class BikeServiceHandlerTest {
 
     @Test
     public void add_ShouldReturnBikeForAdminResponseDTO_WhenGivenBikeRequestDTO() {
-        //given
-        bikeRepository.deleteAll();
-        BikeRequestDTO bikeRequestDTO = new BikeRequestDTO();
-        BikeForAdminResponseDTO expected = modelMapper.map(bikeRequestDTO, BikeForAdminResponseDTO.class);
+        //Arrange
+        when(modelMapper.map(bikeRequestDTO, Bike.class)).thenReturn(bike);
+        when(bikeRepository.save(bike)).thenReturn(bike);
+        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
 
-        //when
+        //Act
         BikeForAdminResponseDTO actual = bikeServiceHandler.add(bikeRequestDTO);
 
-        //then
-        assertNotNull(actual.getId());  // check that ID is not null
-        expected.setId(actual.getId());  // set expected ID to actual ID
-        assertEquals(expected, actual);
+        //Assert
+        assertEquals(bikeForAdminResponseDTO, actual);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -112,39 +112,37 @@ class BikeServiceHandlerTest {
 
     @Test
     public void update_ShouldReturnUpdatedBikeForAdminResponseDTO_WhenGivenCorrectIdAndBikeRequestDTO() {
-        //given
-        bikeRepository.deleteAll();
-        Bike bike = new Bike();
+        //Arrange
+        bike = new Bike();
         bike.setRent(new Rent());
 
-        ChargingStation chargingStation = new ChargingStation();
-        chargingStationRepository.save(chargingStation);
+        ChargingStation chargingStation = mock(ChargingStation.class);
+        User user = mock(User.class);
+        UserForAdminResponseDTO userDTO = mock(UserForAdminResponseDTO.class);
+        GpsCoordinates gpsCoordinates = mock(GpsCoordinates.class);
+        StationForAdminResponseDTO stationDTO = mock(StationForAdminResponseDTO.class);
 
-        User user = new User();
-        userRepository.save(user);
+        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+        when(bikeRepository.save(bike)).thenReturn(bike);
+        when(modelMapper.map(bike, BikeForAdminResponseDTO.class)).thenReturn(bikeForAdminResponseDTO);
 
         bike.setId(bike.getId());
         bike.setSerialNumber("123");
         bike.setRented(true);
         bike.setBikeType(BikeType.ELECTRIC);
         bike.getRent().setAmountToBePaid(100.00);
-        bike.setGpsCoordinates(new GpsCoordinates("50N", "40E"));
+        bike.setGpsCoordinates(gpsCoordinates);
         bike.setUser(user);
         bike.setChargingStation(chargingStation);
 
-        bikeRepository.save(bike);
-
-        BikeForAdminResponseDTO expected = modelMapper.map(bike, BikeForAdminResponseDTO.class);
-
         BikeRequestDTO bikeRequestDTO = new BikeRequestDTO(bike.getId(), "123", true, BikeType.ELECTRIC,
-                100.00, new GpsCoordinates("50N", "40E"), new UserForAdminResponseDTO(),
-                new StationForAdminResponseDTO());
+                100.00, gpsCoordinates, userDTO, stationDTO);
 
-        //when
+        //Act
         BikeForAdminResponseDTO actual = bikeServiceHandler.update(bike.getId(), bikeRequestDTO);
 
-        //then
-        assertEquals(expected, actual);
+        //Assert
+        assertEquals(bikeForAdminResponseDTO, actual);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/BikeServiceHandlerTest.java
@@ -171,34 +171,31 @@ class BikeServiceHandlerTest {
         //Act
         bikeServiceHandler.deleteById(bike.getId());
 
-        //then
+        //Assert
         verify(bikeRepository, times(1)).deleteById(bike.getId());
     }
 
     @Test
     public void findByIsRentedFalse_ShouldReturnListOfNotRentedBikes_WhenRentIsFalse() {
-        //given
-        bikeRepository.deleteAll();
+        //Arrange
         List<Bike> expected = new ArrayList<>();
 
-        Bike bike = new Bike();
+        Bike bike1 = new Bike();
+        bike1.setRented(true);
         Bike bike2 = new Bike();
+        bike2.setRented(false);
         Bike bike3 = new Bike();
-
-        bike.setRented(true);
         bike3.setRented(true);
-
-        bikeRepository.save(bike);
-        bikeRepository.save(bike2);
-        bikeRepository.save(bike3);
 
         expected.add(bike2);
 
-        //when
+        when(bikeRepository.findByIsRentedFalse()).thenReturn(expected);
+
+        //Act
         List<Bike> actual = bikeServiceHandler.findByIsRentedFalse();
 
-        //then
-        assertEquals(expected, actual);
+        //Assert
+        assertIterableEquals(expected, actual);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -69,9 +69,9 @@ class ChargingStationServiceHandlerTest {
         List<StationForAdminResponseDTO> expectedStationDTOS = new ArrayList<>();
         StationForAdminResponseDTO stationDTO = new StationForAdminResponseDTO();
         when(chargingStationRepository.findAll()).thenReturn(stations);
+        when(modelMapper.map(chargingStation, StationForAdminResponseDTO.class)).thenReturn(stationDTO);
 
         for (int i = 0; i < 5; i++) {
-            when(modelMapper.map(chargingStation, StationForAdminResponseDTO.class)).thenReturn(stationDTO);
             expectedStationDTOS.add(stationDTO);
             stations.add(chargingStation);
         }

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -63,20 +63,24 @@ class ChargingStationServiceHandlerTest {
     }
 
     @Test
-    public void findAll_ShouldReturnListOfStationForAdminResponseDTO_WhenExistInDatabase() {
-        //given
+    public void findAll_ShouldReturnListOfStationForAdminResponseDTO_WhenBikesExistInDatabase() {
+        //Arrange
+        List<ChargingStation> stations = new ArrayList<>();
         List<StationForAdminResponseDTO> expectedStationDTOS = new ArrayList<>();
+        StationForAdminResponseDTO stationDTO = new StationForAdminResponseDTO();
+        when(chargingStationRepository.findAll()).thenReturn(stations);
+
         for (int i = 0; i < 5; i++) {
-            ChargingStation chargingStation = new ChargingStation();
-            chargingStationRepository.save(chargingStation);
-            StationForAdminResponseDTO stationDTO = modelMapper.map(chargingStation, StationForAdminResponseDTO.class);
+            when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
+            when(modelMapper.map(chargingStation, StationForAdminResponseDTO.class)).thenReturn(stationDTO);
             expectedStationDTOS.add(stationDTO);
+            stations.add(chargingStation);
         }
 
-        //when
+        //Act
         List<StationForAdminResponseDTO> actual = chargingStationServiceHandler.findAll();
 
-        //then
+        //Assert
         assertEquals(expectedStationDTOS, actual);
     }
 
@@ -141,7 +145,7 @@ class ChargingStationServiceHandlerTest {
         List<Bike> bikeList = new ArrayList<>();
         bikeList.add(bike);
 
-        ChargingStation chargingStation =  new ChargingStation();
+        ChargingStation chargingStation = new ChargingStation();
         chargingStationRepository.save(chargingStation);
 
         //when

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -11,6 +11,7 @@ import org.modelmapper.ModelMapper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -86,16 +87,16 @@ class ChargingStationServiceHandlerTest {
 
     @Test
     public void findById_ShouldReturnStationForAdminResponseDTO_WhenExistInDatabase() {
-        //given
-        ChargingStation chargingStation = new ChargingStation();
-        chargingStationRepository.save(chargingStation);
-        StationForAdminResponseDTO expected = modelMapper.map(chargingStation, StationForAdminResponseDTO.class);
+        //Arrange
+        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+        StationForAdminResponseDTO stationDTO = new StationForAdminResponseDTO();
+        when(modelMapper.map(chargingStation, StationForAdminResponseDTO.class)).thenReturn(stationDTO);
 
-        //when
+        //Act
         StationForAdminResponseDTO actual = chargingStationServiceHandler.findById(chargingStation.getId());
 
-        //then
-        assertEquals(expected, actual);
+        //Assert
+        assertEquals(stationDTO, actual);
     }
 
 

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -50,17 +50,16 @@ class ChargingStationServiceHandlerTest {
 
     @Test
     public void add_ShouldReturnStationForAdminResponseDTO_WhenGivenChargingStation() {
-        //given
-        ChargingStation chargingStation = new ChargingStation();
-        StationForAdminResponseDTO expected = modelMapper.map(chargingStation, StationForAdminResponseDTO.class);
+        //Arrange
+        StationForAdminResponseDTO stationDTO = new StationForAdminResponseDTO();
+        when(modelMapper.map(chargingStation, StationForAdminResponseDTO.class)).thenReturn(stationDTO);
+        when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
 
-        //when
+        //Act
         StationForAdminResponseDTO actual = chargingStationServiceHandler.add(chargingStation);
 
-        //then
-        assertNotNull(actual.getId());
-        expected.setId(actual.getId());
-        assertEquals(expected, actual);
+        //Assert
+        assertEquals(stationDTO, actual);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -122,32 +122,36 @@ class ChargingStationServiceHandlerTest {
 
     @Test
     public void save_ShouldCallOnChargingStationRepositoryExactlyOnce_WhenChargingStationIsProvided() {
-        //given
+        //Arrange
         when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
 
-        //when
+        //Act
         chargingStationServiceHandler.save(chargingStation);
 
-        //then
+        //Assert
         verify(chargingStationRepository, times(1)).save(chargingStation);
     }
 
     @Test
-    public void addBikeToList_ShouldAddBikeToList_WhenProvidedCorrectArguments() {
-        //given
-        Bike bike = new Bike();
-        bikeRepository.save(bike);
-
+    public void addBikeToList_ShouldAddBikeToList_WhenIdsOfBikeAndStationAreProvided() {
+        //Arrange
         List<Bike> bikeList = new ArrayList<>();
+        Bike bike = new Bike();
         bikeList.add(bike);
 
-        ChargingStation chargingStation = new ChargingStation();
-        chargingStationRepository.save(chargingStation);
+        chargingStation = new ChargingStation();
 
-        //when
+        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+        when(bikeServiceHandler.findBikeById(bike.getId())).thenReturn(bike);
+        when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
+
+        bike.setChargingStation(chargingStation);
+        chargingStation.setBikeList(bikeList);
+
+        //Act
         List<Bike> actual = chargingStationServiceHandler.addBikeToList(chargingStation.getId(), bike.getId()).getBikeList();
 
-        //then
+        //Assert
         assertIterableEquals(bikeList, actual);
     }
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -121,17 +121,15 @@ class ChargingStationServiceHandlerTest {
 
 
     @Test
-    public void save_ShouldSaveInDatabase_WhenProvidedChargingStationObject() {
+    public void save_ShouldCallOnChargingStationRepositoryExactlyOnce_WhenChargingStationIsProvided() {
         //given
-        ChargingStation chargingStation = new ChargingStation();
-        Long expected = chargingStationRepository.count() + 1;
+        when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
 
         //when
         chargingStationServiceHandler.save(chargingStation);
-        Long actual = chargingStationRepository.count();
 
         //then
-        assertEquals(expected, actual);
+        verify(chargingStationRepository, times(1)).save(chargingStation);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -8,29 +8,30 @@ import com.klodnicki.Bike.v2.repository.ChargingStationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
-@SpringBootTest
+
 class ChargingStationServiceHandlerTest {
 
-    @Autowired
     private ChargingStationRepository chargingStationRepository;
-    @Autowired
     private BikeRepository bikeRepository;
-    @Autowired
     private ChargingStationServiceHandler chargingStationServiceHandler;
-    @Autowired
+    private BikeServiceHandler bikeServiceHandler;
     private ModelMapper modelMapper;
 
     @BeforeEach
-    public void cleanDatabase() {
-        chargingStationRepository.deleteAll();
+    public void setUp() {
+        chargingStationRepository = mock(ChargingStationRepository.class);
+        bikeRepository = mock(BikeRepository.class);
+        bikeServiceHandler = mock(BikeServiceHandler.class);
+        modelMapper = mock(ModelMapper.class);
+        chargingStationServiceHandler = new ChargingStationServiceHandler(chargingStationRepository, bikeServiceHandler,
+                modelMapper);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -99,18 +99,15 @@ class ChargingStationServiceHandlerTest {
         assertEquals(stationDTO, actual);
     }
 
-
     @Test
     public void findStationById_ShouldReturnChargingStation_WhenExistInDatabase() {
-        //given
-        ChargingStation chargingStation = new ChargingStation();
-        chargingStation.setBikeList(new ArrayList<>());
-        chargingStationRepository.save(chargingStation);
+        //Arrange
+        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
 
-        //when
+        //Act
         ChargingStation actual = chargingStationServiceHandler.findStationById(chargingStation.getId());
 
-        //then
+        //Assert
         assertEquals(chargingStation, actual);
     }
 

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -35,17 +35,16 @@ class ChargingStationServiceHandlerTest {
     }
 
     @Test
-    public void add_ShouldAddToDatabase_WhenGivenCorrectArguments() {
-        //given
-        Long expected = chargingStationRepository.count() + 1;
-        ChargingStation chargingStation = new ChargingStation();
+    public void add_ShouldCallOnChargingStationRepositoryExactlyOnce_WhenChargingStationProvided() {
+        //Arrange
+        ChargingStation chargingStation = mock(ChargingStation.class);
+        when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
 
-        //when
+        //Act
         chargingStationServiceHandler.add(chargingStation);
-        Long actual = chargingStationRepository.count();
 
-        //then
-        assertEquals(expected, actual);
+        //Assert
+        verify(chargingStationRepository, times(1)).save(chargingStation);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -23,6 +23,7 @@ class ChargingStationServiceHandlerTest {
     private ChargingStationServiceHandler chargingStationServiceHandler;
     private BikeServiceHandler bikeServiceHandler;
     private ModelMapper modelMapper;
+    private ChargingStation chargingStation;
 
     @BeforeEach
     public void setUp() {
@@ -32,12 +33,12 @@ class ChargingStationServiceHandlerTest {
         modelMapper = mock(ModelMapper.class);
         chargingStationServiceHandler = new ChargingStationServiceHandler(chargingStationRepository, bikeServiceHandler,
                 modelMapper);
+        chargingStation = mock(ChargingStation.class);
     }
 
     @Test
     public void add_ShouldCallOnChargingStationRepositoryExactlyOnce_WhenChargingStationProvided() {
         //Arrange
-        ChargingStation chargingStation = mock(ChargingStation.class);
         when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
 
         //Act

--- a/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/ChargingStationServiceHandlerTest.java
@@ -35,13 +35,13 @@ class ChargingStationServiceHandlerTest {
         chargingStationServiceHandler = new ChargingStationServiceHandler(chargingStationRepository, bikeServiceHandler,
                 modelMapper);
         chargingStation = mock(ChargingStation.class);
+
+        when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
     }
 
     @Test
     public void add_ShouldCallOnChargingStationRepositoryExactlyOnce_WhenChargingStationProvided() {
-        //Arrange
-        when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
-
+        //Arrange - takes from @BeforeEach setUp()
         //Act
         chargingStationServiceHandler.add(chargingStation);
 
@@ -51,10 +51,9 @@ class ChargingStationServiceHandlerTest {
 
     @Test
     public void add_ShouldReturnStationForAdminResponseDTO_WhenGivenChargingStation() {
-        //Arrange
+        //Arrange - takes from @BeforeEach setUp()
         StationForAdminResponseDTO stationDTO = new StationForAdminResponseDTO();
         when(modelMapper.map(chargingStation, StationForAdminResponseDTO.class)).thenReturn(stationDTO);
-        when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
 
         //Act
         StationForAdminResponseDTO actual = chargingStationServiceHandler.add(chargingStation);
@@ -65,14 +64,13 @@ class ChargingStationServiceHandlerTest {
 
     @Test
     public void findAll_ShouldReturnListOfStationForAdminResponseDTO_WhenBikesExistInDatabase() {
-        //Arrange
+        //Arrange - takes from @BeforeEach setUp()
         List<ChargingStation> stations = new ArrayList<>();
         List<StationForAdminResponseDTO> expectedStationDTOS = new ArrayList<>();
         StationForAdminResponseDTO stationDTO = new StationForAdminResponseDTO();
         when(chargingStationRepository.findAll()).thenReturn(stations);
 
         for (int i = 0; i < 5; i++) {
-            when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
             when(modelMapper.map(chargingStation, StationForAdminResponseDTO.class)).thenReturn(stationDTO);
             expectedStationDTOS.add(stationDTO);
             stations.add(chargingStation);
@@ -113,18 +111,13 @@ class ChargingStationServiceHandlerTest {
 
     @Test
     public void findStationById_ShouldThrowIllegalArgumentException_WhenNotFoundChargingStationInDatabase() {
-        //given
-        //when
-        //then
         assertThrows(IllegalArgumentException.class, () -> chargingStationServiceHandler.findStationById(1L));
     }
 
 
     @Test
     public void save_ShouldCallOnChargingStationRepositoryExactlyOnce_WhenChargingStationIsProvided() {
-        //Arrange
-        when(chargingStationRepository.save(chargingStation)).thenReturn(chargingStation);
-
+        //Arrange - takes from @BeforeEach setUp()
         //Act
         chargingStationServiceHandler.save(chargingStation);
 

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -63,8 +63,7 @@ class RentBikeServiceHandlerTest {
     @Test
     public void updateRent_ShouldReturnUpdatedDaysOfRentResponseDTO_WhenGivenCorrectArguments() {
         //Arrange
-        rent = new Rent();
-        rent.setId(1L);
+        rent = mock(Rent.class);
 
         when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
 
@@ -110,8 +109,7 @@ class RentBikeServiceHandlerTest {
     @Test
     public void findBikeForNormalUserById_ShouldReturnBikeForNormalUserResponseDTO_WhenGivenCorrectId() {
         //Arrange
-        bike = new Bike();
-        bike.setId(1L);
+        bike = mock(Bike.class);
         when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
 
         BikeForNormalUserResponseDTO expected = modelMapper.map(bike, BikeForNormalUserResponseDTO.class);

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -148,4 +148,34 @@ class RentBikeServiceHandlerTest {
         assertTrue(actual.isEmpty());
     }
 
+    @Test
+    public void rent_ShouldIncrementFreeSlotsByOne_WhenBikeIsRented() {
+        //Arrange
+        Bike bike = new Bike();
+        bike.setId(1L);
+
+        User user = new User();
+        user.setId(1L);
+
+        ChargingStation chargingStation = new ChargingStation();
+        chargingStation.setId(1L);
+        chargingStation.setFreeSlots(1);
+
+        bike.setChargingStation(chargingStation);
+
+        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+
+        RentRequest rentRequest = new RentRequest(1L, user.getId(), bike.getId(), 10);
+
+        int expected = chargingStation.getFreeSlots() + 1;
+
+        //Act
+        rentBikeServiceHandler.rent(rentRequest);
+        int actual = chargingStation.getFreeSlots();
+
+        //Assert
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -87,14 +87,17 @@ class RentBikeServiceHandlerTest {
         bikeList = new ArrayList<>();
         List<BikeForNormalUserResponseDTO> expected = new ArrayList<>();
 
-        when(bikeRepository.findByIsRentedFalse()).thenReturn(bikeList);
+        when(bikeServiceHandler.findByIsRentedFalse()).thenReturn(bikeList);
 
         for (int i = 0; i < 3; i++) {
             Bike bike = new Bike();
             bike.setRented(false);
             bikeList.add(bike);
 
-            expected.add(modelMapper.map(bike, BikeForNormalUserResponseDTO.class));
+            BikeForNormalUserResponseDTO bikeDto = new BikeForNormalUserResponseDTO();
+            expected.add(bikeDto);
+
+            when(modelMapper.map(bike, BikeForNormalUserResponseDTO.class)).thenReturn(bikeDto);
         }
 
         //Act

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -155,15 +155,16 @@ class RentBikeServiceHandlerTest {
             when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
             when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
             when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+
+            when(bikeServiceHandler.findBikeById(rentRequest.getBikeId())).thenReturn(bike);
+            when(userService.findUserById(rentRequest.getUserId())).thenReturn(user);
+            when(chargingStationService.findStationById(bike.getChargingStation().getId())).thenReturn(chargingStation);
         }
 
         @Test
         public void rent_ShouldRemoveFromBikeList_WhenProvidedBikeObject() {
             //Arrange
             //Act
-            when(bikeServiceHandler.findBikeById(rentRequest.getBikeId())).thenReturn(bike);
-            when(userService.findUserById(rentRequest.getUserId())).thenReturn(user);
-            when(chargingStationService.findStationById(bike.getChargingStation().getId())).thenReturn(chargingStation);
             rentBikeServiceHandler.rent(rentRequest);
             List<Bike> actual = chargingStation.getBikeList();
 

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -114,114 +114,122 @@ class RentBikeServiceHandlerTest {
         assertEquals(expected, actual);
     }
 
-    @Test
-    public void rent_ShouldRemoveFromBikeList_WhenProvidedBikeObject() {
-        //Arrange
-        List<Bike> bikeList = new ArrayList<>();
+    @Nested
+    class nestedTestsForRentMethods {
 
-        Bike bike = new Bike();
-        bike.setId(1L);
-        bikeList.add(bike);
+        public void setUpForRentMethods() {
 
-        User user = new User();
-        user.setId(1L);
+        }
 
-        ChargingStation chargingStation = new ChargingStation();
-        chargingStation.setId(1L);
-        chargingStation.setBikeList(bikeList);
+        @Test
+        public void rent_ShouldRemoveFromBikeList_WhenProvidedBikeObject() {
+            //Arrange
+            List<Bike> bikeList = new ArrayList<>();
 
-        bike.setChargingStation(chargingStation);
+            Bike bike = new Bike();
+            bike.setId(1L);
+            bikeList.add(bike);
 
-        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+            User user = new User();
+            user.setId(1L);
 
-        RentRequest rentRequest = new RentRequest();
-        rentRequest.setId(1L);
-        rentRequest.setBikeId(bike.getId());
-        rentRequest.setUserId(user.getId());
-        rentRequest.setDaysOfRent(10);
+            ChargingStation chargingStation = new ChargingStation();
+            chargingStation.setId(1L);
+            chargingStation.setBikeList(bikeList);
 
-        //Act
-        rentBikeServiceHandler.rent(rentRequest);
-        List<Bike> actual = chargingStation.getBikeList();
+            bike.setChargingStation(chargingStation);
 
-        //Assert
-        assertTrue(actual.isEmpty());
-    }
+            when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+            when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+            when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
 
-    @Test
-    public void rent_ShouldIncrementFreeSlotsByOne_WhenBikeIsRented() {
-        //Arrange
-        Bike bike = new Bike();
-        bike.setId(1L);
+            RentRequest rentRequest = new RentRequest();
+            rentRequest.setId(1L);
+            rentRequest.setBikeId(bike.getId());
+            rentRequest.setUserId(user.getId());
+            rentRequest.setDaysOfRent(10);
 
-        User user = new User();
-        user.setId(1L);
+            //Act
+            rentBikeServiceHandler.rent(rentRequest);
+            List<Bike> actual = chargingStation.getBikeList();
 
-        ChargingStation chargingStation = new ChargingStation();
-        chargingStation.setId(1L);
-        chargingStation.setFreeSlots(1);
+            //Assert
+            assertTrue(actual.isEmpty());
+        }
 
-        bike.setChargingStation(chargingStation);
+        @Test
+        public void rent_ShouldIncrementFreeSlotsByOne_WhenBikeIsRented() {
+            //Arrange
+            Bike bike = new Bike();
+            bike.setId(1L);
 
-        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+            User user = new User();
+            user.setId(1L);
 
-        RentRequest rentRequest = new RentRequest(1L, user.getId(), bike.getId(), 10);
+            ChargingStation chargingStation = new ChargingStation();
+            chargingStation.setId(1L);
+            chargingStation.setFreeSlots(1);
 
-        int expected = chargingStation.getFreeSlots() + 1;
+            bike.setChargingStation(chargingStation);
 
-        //Act
-        rentBikeServiceHandler.rent(rentRequest);
-        int actual = chargingStation.getFreeSlots();
+            when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+            when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+            when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
 
-        //Assert
-        assertEquals(expected, actual);
-    }
+            RentRequest rentRequest = new RentRequest(1L, user.getId(), bike.getId(), 10);
 
-    @Test
-    public void rent_ShouldCallOnRentRepositoryExactlyOnceWithCorrectState_WhenRentProvided() {
-        //Arrange
-        Bike bike = new Bike();
-        bike.setId(1L);
+            int expected = chargingStation.getFreeSlots() + 1;
 
-        User user = new User();
-        user.setId(1L);
+            //Act
+            rentBikeServiceHandler.rent(rentRequest);
+            int actual = chargingStation.getFreeSlots();
 
-        ChargingStation chargingStation = new ChargingStation();
-        chargingStation.setId(1L);
+            //Assert
+            assertEquals(expected, actual);
+        }
 
-        bike.setChargingStation(chargingStation);
+        @Test
+        public void rent_ShouldCallOnRentRepositoryExactlyOnceWithCorrectState_WhenRentProvided() {
+            //Arrange
+            Bike bike = new Bike();
+            bike.setId(1L);
 
-        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
-        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+            User user = new User();
+            user.setId(1L);
 
-        RentRequest rentRequest = new RentRequest(1L, user.getId(), bike.getId(), 10);
+            ChargingStation chargingStation = new ChargingStation();
+            chargingStation.setId(1L);
 
-        //Act
-        rentBikeServiceHandler.rent(rentRequest);
+            bike.setChargingStation(chargingStation);
 
-        //Assert
-        ArgumentCaptor<Rent> rentCaptor = ArgumentCaptor.forClass(Rent.class); //I capture a Rent object which is passed
-        // to save(), because rent in test method and rent in original method are two different instances
+            when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+            when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+            when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
 
-        verify(rentRepository, times(1)).save(rentCaptor.capture()); //I verify if the save method
-        // of rentRepository is called exactly once. The rentCaptor.capture() I use as the argument to save,
-        // this tells Mockito to capture the argument that is passed in when save is called.
+            RentRequest rentRequest = new RentRequest(1L, user.getId(), bike.getId(), 10);
 
-        Rent capturedRent = rentCaptor.getValue(); //I get the captured value
+            //Act
+            rentBikeServiceHandler.rent(rentRequest);
 
-        assertEquals(bike, capturedRent.getBike()); // I check if these objects are equals to the objects which I set up
-        // earlier in my test method
-        assertEquals(user, capturedRent.getUser());
-        assertEquals(rentRequest.getDaysOfRent(), capturedRent.getDaysOfRent());
+            //Assert
+            ArgumentCaptor<Rent> rentCaptor = ArgumentCaptor.forClass(Rent.class); //I capture a Rent object which is passed
+            // to save(), because rent in test method and rent in original method are two different instances
 
-        //So this code captures Rent object that is passed to rentRepository.save(), and then it checks if its fields
-        // have the expected values. So that I not only check if it was called once, but also if arguments
-        // themselves have the correct state.
+            verify(rentRepository, times(1)).save(rentCaptor.capture()); //I verify if the save method
+            // of rentRepository is called exactly once. The rentCaptor.capture() I use as the argument to save,
+            // this tells Mockito to capture the argument that is passed in when save is called.
+
+            Rent capturedRent = rentCaptor.getValue(); //I get the captured value
+
+            assertEquals(bike, capturedRent.getBike()); // I check if these objects are equals to the objects which I set up
+            // earlier in my test method
+            assertEquals(user, capturedRent.getUser());
+            assertEquals(rentRequest.getDaysOfRent(), capturedRent.getDaysOfRent());
+
+            //So this code captures Rent object that is passed to rentRepository.save(), and then it checks if its fields
+            // have the expected values. So that I not only check if it was called once, but also if arguments
+            // themselves have the correct state.
+        }
     }
 
     @Nested

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.modelmapper.ModelMapper;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -220,5 +221,41 @@ class RentBikeServiceHandlerTest {
         //So this code captures Rent object that is passed to rentRepository.save(), and then it checks if its fields
         // have the expected values. So that I not only check if it was called once, but also if arguments
         // themselves have the correct state.
+    }
+
+    @Test
+    public void returnVehicle_ShouldAddReturnedBikeToStation_WhenGivenBikeObject() {
+        //Arrange
+        List<Bike> bikeList = new ArrayList<>();
+
+        Rent rent = mock(Rent.class);
+        rent.setId(1L);
+
+        Bike bike = mock(Bike.class);
+        bike.setId(1L);
+
+        ChargingStation chargingStation = new ChargingStation(); //I cannot have here mock(ChargingStation.class) because
+        //later I'm not able to set a bikeList to it.
+        chargingStation.setId(1L);
+
+        User user = mock(User.class);
+        user.setId(1L);
+
+        bikeList.add(bike);
+        chargingStation.setBikeList(bikeList);
+
+        when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
+        when(rent.getBike()).thenReturn(bike);
+        when(rent.getUser()).thenReturn(user);
+        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+        when(rent.getRentalStartTime()).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));
+        when(rent.getRentalEndTime()).thenReturn( LocalDateTime.of(2023, 1, 1, 1, 0));
+
+        //Act
+        rentBikeServiceHandler.returnVehicle(rent.getId(), chargingStation.getId());
+        List<Bike> actual = chargingStation.getBikeList();
+
+        //Assert
+        assertIterableEquals(bikeList, actual);
     }
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -229,24 +229,19 @@ class RentBikeServiceHandlerTest {
         List<Bike> bikeList = new ArrayList<>();
 
         Rent rent = mock(Rent.class);
-        rent.setId(1L);
-
+        User user = mock(User.class);
         Bike bike = mock(Bike.class);
-        bike.setId(1L);
 
         ChargingStation chargingStation = new ChargingStation(); //I cannot have here mock(ChargingStation.class) because
-        //later I'm not able to set a bikeList to it.
+        //I test behaviour of this object, and later I would not able to set a bikeList to it.
         chargingStation.setId(1L);
-
-        User user = mock(User.class);
-        user.setId(1L);
 
         bikeList.add(bike);
         chargingStation.setBikeList(bikeList);
 
         when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
-        when(rent.getBike()).thenReturn(bike); //I should create mocks for bike and user so that Mockito will return the mock objects
-        //and I can define their behaviour
+        when(rent.getBike()).thenReturn(bike); //I should create mocks so that I don't have to set up these instances,
+        // Mockito will return the mock objects, and then I can define their behaviour by thenReturn
         when(rent.getUser()).thenReturn(user);
         when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
         when(rent.getRentalStartTime()).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -254,4 +254,33 @@ class RentBikeServiceHandlerTest {
         //Assert
         assertIterableEquals(bikeList, actual);
     }
+
+    @Test
+    public void returnVehicle_ShouldDecrementStationFreeSlotsByOne_WhenBikeIsReturned() {
+        //Arrange
+        List<Bike> bikeList = new ArrayList<>();
+
+        Rent rent = mock(Rent.class);
+        User user = mock(User.class);
+        Bike bike = mock(Bike.class);
+        ChargingStation chargingStation = new ChargingStation();
+        chargingStation.setId(1L);
+        chargingStation.setFreeSlots(1); //should decrement by one
+        chargingStation.setBikeList(bikeList);
+
+        when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
+        when(rent.getBike()).thenReturn(bike); //I should create mocks so that I don't have to set up these instances,
+        // Mockito will return the mock objects, and then I can define their behaviour by thenReturn
+        when(rent.getUser()).thenReturn(user);
+        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+        when(rent.getRentalStartTime()).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));
+        when(rent.getRentalEndTime()).thenReturn( LocalDateTime.of(2023, 1, 1, 1, 0));
+
+        //Act
+        rentBikeServiceHandler.returnVehicle(rent.getId(), chargingStation.getId());
+        int actual = chargingStation.getFreeSlots();
+
+        //Assert
+        assertEquals(0, actual);
+    }
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -122,38 +122,40 @@ class RentBikeServiceHandlerTest {
     @Nested
     class nestedTestsForRentMethods {
 
+        private RentRequest rentRequest;
+
+        @BeforeEach
         public void setUpForRentMethods() {
 
-        }
+            bikeList = new ArrayList<>();
 
-        @Test
-        public void rent_ShouldRemoveFromBikeList_WhenProvidedBikeObject() {
-            //Arrange
-            List<Bike> bikeList = new ArrayList<>();
-
-            Bike bike = new Bike();
+            bike = new Bike();
             bike.setId(1L);
             bikeList.add(bike);
 
-            User user = new User();
+            user = new User();
             user.setId(1L);
 
-            ChargingStation chargingStation = new ChargingStation();
+            chargingStation = new ChargingStation();
             chargingStation.setId(1L);
             chargingStation.setBikeList(bikeList);
+
+            rentRequest = new RentRequest();
+            rentRequest.setId(1L);
+            rentRequest.setBikeId(bike.getId());
+            rentRequest.setUserId(user.getId());
+            rentRequest.setDaysOfRent(10);
 
             bike.setChargingStation(chargingStation);
 
             when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
             when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
             when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+        }
 
-            RentRequest rentRequest = new RentRequest();
-            rentRequest.setId(1L);
-            rentRequest.setBikeId(bike.getId());
-            rentRequest.setUserId(user.getId());
-            rentRequest.setDaysOfRent(10);
-
+        @Test
+        public void rent_ShouldRemoveFromBikeList_WhenProvidedBikeObject() {
+            //Arrange
             //Act
             rentBikeServiceHandler.rent(rentRequest);
             List<Bike> actual = chargingStation.getBikeList();
@@ -165,24 +167,7 @@ class RentBikeServiceHandlerTest {
         @Test
         public void rent_ShouldIncrementFreeSlotsByOne_WhenBikeIsRented() {
             //Arrange
-            Bike bike = new Bike();
-            bike.setId(1L);
-
-            User user = new User();
-            user.setId(1L);
-
-            ChargingStation chargingStation = new ChargingStation();
-            chargingStation.setId(1L);
             chargingStation.setFreeSlots(1);
-
-            bike.setChargingStation(chargingStation);
-
-            when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
-            when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-            when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
-
-            RentRequest rentRequest = new RentRequest(1L, user.getId(), bike.getId(), 10);
-
             int expected = chargingStation.getFreeSlots() + 1;
 
             //Act
@@ -196,23 +181,6 @@ class RentBikeServiceHandlerTest {
         @Test
         public void rent_ShouldCallOnRentRepositoryExactlyOnceWithCorrectState_WhenRentProvided() {
             //Arrange
-            Bike bike = new Bike();
-            bike.setId(1L);
-
-            User user = new User();
-            user.setId(1L);
-
-            ChargingStation chargingStation = new ChargingStation();
-            chargingStation.setId(1L);
-
-            bike.setChargingStation(chargingStation);
-
-            when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
-            when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-            when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
-
-            RentRequest rentRequest = new RentRequest(1L, user.getId(), bike.getId(), 10);
-
             //Act
             rentBikeServiceHandler.rent(rentRequest);
 
@@ -239,12 +207,6 @@ class RentBikeServiceHandlerTest {
 
     @Nested
     class nestedTestsForReturnVehicleMethods {
-
-        private ChargingStation chargingStation;
-        private Rent rent;
-        private User user;
-        private Bike bike;
-        private List<Bike> bikeList;
 
         @BeforeEach
         public void setUpForReturnVehicleMethod() {

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -52,11 +52,12 @@ class RentBikeServiceHandlerTest {
         chargingStationRepository = mock(ChargingStationRepository.class);
         userRepository = mock(UserRepository.class);
 
-        modelMapper = new ModelMapper();
-        bikeServiceHandler = new BikeServiceHandler(bikeRepository, modelMapper);
-        userService = new UserServiceHandler(userRepository, modelMapper);
-        chargingStationService = new ChargingStationServiceHandler(chargingStationRepository, bikeServiceHandler, modelMapper);
-        rentBikeServiceHandler = new RentBikeServiceHandler(bikeServiceHandler, chargingStationService, userService, modelMapper, rentRepository);
+        modelMapper = mock(ModelMapper.class);
+        bikeServiceHandler = mock(BikeServiceHandler.class);
+        userService = mock(UserServiceHandler.class);
+        chargingStationService = mock(ChargingStationServiceHandler.class);
+        rentBikeServiceHandler = new RentBikeServiceHandler(bikeServiceHandler, chargingStationService, userService,
+                modelMapper, rentRepository);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -1,0 +1,47 @@
+package com.klodnicki.Bike.v2.service;
+
+import com.klodnicki.Bike.v2.DTO.rent.RentRequestDTO;
+import com.klodnicki.Bike.v2.DTO.rent.RentResponseDTO;
+import com.klodnicki.Bike.v2.model.entity.Rent;
+import com.klodnicki.Bike.v2.repository.BikeRepository;
+import com.klodnicki.Bike.v2.repository.ChargingStationRepository;
+import com.klodnicki.Bike.v2.repository.RentRepository;
+import com.klodnicki.Bike.v2.repository.UserRepository;
+import com.klodnicki.Bike.v2.service.api.ChargingStationServiceApi;
+import com.klodnicki.Bike.v2.service.api.UserServiceApi;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RentBikeServiceHandlerTest {
+
+    private RentRepository rentRepository;
+    private BikeRepository bikeRepository;
+    private ChargingStationRepository chargingStationRepository;
+    private UserRepository userRepository;
+    private ModelMapper modelMapper;
+    private RentBikeServiceHandler rentBikeServiceHandler;
+    private BikeServiceHandler bikeServiceHandler;
+    private ChargingStationServiceApi chargingStationService;
+    private UserServiceApi userService;
+
+    @BeforeEach
+    public void setUp() {
+        rentRepository = mock(RentRepository.class);
+        bikeRepository = mock(BikeRepository.class);
+        chargingStationRepository = mock(ChargingStationRepository.class);
+        userRepository = mock(UserRepository.class);
+
+        modelMapper = new ModelMapper();
+        bikeServiceHandler = new BikeServiceHandler(bikeRepository, modelMapper);
+        userService = new UserServiceHandler(userRepository, modelMapper);
+        chargingStationService = new ChargingStationServiceHandler(chargingStationRepository, bikeServiceHandler, modelMapper);
+        rentBikeServiceHandler = new RentBikeServiceHandler(bikeServiceHandler, chargingStationService, userService, modelMapper, rentRepository);
+    }
+}

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -234,7 +234,7 @@ class RentBikeServiceHandlerTest {
         private List<Bike> bikeList;
 
         @BeforeEach
-        public void setUpForRentMethod() {
+        public void setUpForReturnVehicleMethod() {
             bikeList = new ArrayList<>();
 
             rent = mock(Rent.class);

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -137,8 +137,7 @@ class RentBikeServiceHandlerTest {
             bike.setId(1L);
             bikeList.add(bike);
 
-            user = new User();
-            user.setId(1L);
+            user = mock(User.class);
 
             chargingStation = new ChargingStation();
             chargingStation.setId(1L);

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -39,6 +39,11 @@ class RentBikeServiceHandlerTest {
     private BikeServiceHandler bikeServiceHandler;
     private ChargingStationServiceApi chargingStationService;
     private UserServiceApi userService;
+    private ChargingStation chargingStation;
+    private Rent rent;
+    private User user;
+    private Bike bike;
+    private List<Bike> bikeList;
 
     @BeforeEach
     public void setUp() {
@@ -57,7 +62,7 @@ class RentBikeServiceHandlerTest {
     @Test
     public void updateRent_ShouldReturnUpdatedDaysOfRentResponseDTO_WhenGivenCorrectArguments() {
         //Arrange
-        Rent rent = new Rent();
+        rent = new Rent();
         rent.setId(1L);
 
         when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
@@ -78,15 +83,15 @@ class RentBikeServiceHandlerTest {
     @Test
     public void findAvailableBikes_ShouldReturnListOfBikeForNormalUserResponseDTO_WhenGivenListOfBikes() {
         //Arrange
-        List<Bike> listOfBikes = new ArrayList<>();
+        bikeList = new ArrayList<>();
         List<BikeForNormalUserResponseDTO> expected = new ArrayList<>();
 
-        when(bikeRepository.findByIsRentedFalse()).thenReturn(listOfBikes);
+        when(bikeRepository.findByIsRentedFalse()).thenReturn(bikeList);
 
         for (int i = 0; i < 3; i++) {
             Bike bike = new Bike();
             bike.setRented(false);
-            listOfBikes.add(bike);
+            bikeList.add(bike);
 
             expected.add(modelMapper.map(bike, BikeForNormalUserResponseDTO.class));
         }
@@ -101,7 +106,7 @@ class RentBikeServiceHandlerTest {
     @Test
     public void findBikeForNormalUserById_ShouldReturnBikeForNormalUserResponseDTO_WhenGivenCorrectId() {
         //Arrange
-        Bike bike = new Bike();
+        bike = new Bike();
         bike.setId(1L);
         when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
 

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -3,8 +3,11 @@ package com.klodnicki.Bike.v2.service;
 import com.klodnicki.Bike.v2.DTO.bike.BikeForNormalUserResponseDTO;
 import com.klodnicki.Bike.v2.DTO.rent.RentRequestDTO;
 import com.klodnicki.Bike.v2.DTO.rent.RentResponseDTO;
+import com.klodnicki.Bike.v2.model.RentRequest;
 import com.klodnicki.Bike.v2.model.entity.Bike;
+import com.klodnicki.Bike.v2.model.entity.ChargingStation;
 import com.klodnicki.Bike.v2.model.entity.Rent;
+import com.klodnicki.Bike.v2.model.entity.User;
 import com.klodnicki.Bike.v2.repository.BikeRepository;
 import com.klodnicki.Bike.v2.repository.ChargingStationRepository;
 import com.klodnicki.Bike.v2.repository.RentRepository;
@@ -19,8 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -109,4 +111,41 @@ class RentBikeServiceHandlerTest {
         //Assert
         assertEquals(expected, actual);
     }
+
+    @Test
+    public void rent_ShouldRemoveFromBikeList_WhenProvidedBikeObject() {
+        //Arrange
+        List<Bike> bikeList = new ArrayList<>();
+
+        Bike bike = new Bike();
+        bike.setId(1L);
+        bikeList.add(bike);
+
+        User user = new User();
+        user.setId(1L);
+
+        ChargingStation chargingStation = new ChargingStation();
+        chargingStation.setId(1L);
+        chargingStation.setBikeList(bikeList);
+
+        bike.setChargingStation(chargingStation);
+
+        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+
+        RentRequest rentRequest = new RentRequest();
+        rentRequest.setId(1L);
+        rentRequest.setBikeId(bike.getId());
+        rentRequest.setUserId(user.getId());
+        rentRequest.setDaysOfRent(10);
+
+        //Act
+        rentBikeServiceHandler.rent(rentRequest);
+        List<Bike> actual = chargingStation.getBikeList();
+
+        //Assert
+        assertTrue(actual.isEmpty());
+    }
+
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -93,4 +93,20 @@ class RentBikeServiceHandlerTest {
         //Assert
         assertIterableEquals(expected, actual);
     }
+
+    @Test
+    public void findBikeForNormalUserById_ShouldReturnBikeForNormalUserResponseDTO_WhenGivenCorrectId() {
+        //Arrange
+        Bike bike = new Bike();
+        bike.setId(1L);
+        when(bikeRepository.findById(bike.getId())).thenReturn(Optional.of(bike));
+
+        BikeForNormalUserResponseDTO expected = modelMapper.map(bike, BikeForNormalUserResponseDTO.class);
+
+        //Act
+        BikeForNormalUserResponseDTO actual = rentBikeServiceHandler.findBikeForNormalUserById(bike.getId());
+
+        //Assert
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -245,7 +245,8 @@ class RentBikeServiceHandlerTest {
         chargingStation.setBikeList(bikeList);
 
         when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
-        when(rent.getBike()).thenReturn(bike);
+        when(rent.getBike()).thenReturn(bike); //I should create mocks for bike and user so that Mockito will return the mock objects
+        //and I can define their behaviour
         when(rent.getUser()).thenReturn(user);
         when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
         when(rent.getRentalStartTime()).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -44,4 +44,25 @@ class RentBikeServiceHandlerTest {
         chargingStationService = new ChargingStationServiceHandler(chargingStationRepository, bikeServiceHandler, modelMapper);
         rentBikeServiceHandler = new RentBikeServiceHandler(bikeServiceHandler, chargingStationService, userService, modelMapper, rentRepository);
     }
+
+    @Test
+    public void updateRent_ShouldReturnUpdatedDaysOfRentResponseDTO_WhenGivenCorrectArguments() {
+        //Arrange
+        Rent rent = new Rent();
+        rent.setId(1L);
+
+        when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
+
+        RentRequestDTO rentRequestDTO = new RentRequestDTO();
+        rentRequestDTO.setId(1L);
+        rentRequestDTO.setDaysOfRent(10);
+
+        RentResponseDTO expected = modelMapper.map(rentRequestDTO, RentResponseDTO.class);
+
+        //Act
+        RentResponseDTO actual = rentBikeServiceHandler.updateRent(rent.getId(), rentRequestDTO);
+
+        //Assert
+        assertEquals(expected, actual);
+    }
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -229,10 +229,11 @@ class RentBikeServiceHandlerTest {
             when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
             when(rent.getBike()).thenReturn(bike); //I should create mocks so that I don't have to set up these instances,
             // Mockito will return the mock objects, and then I can define their behaviour by thenReturn
+            when(chargingStationService.findStationById(chargingStation.getId())).thenReturn(chargingStation);
             when(rent.getUser()).thenReturn(user);
             when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
             when(rent.getRentalStartTime()).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));
-            when(rent.getRentalEndTime()).thenReturn( LocalDateTime.of(2023, 1, 1, 1, 0));
+            when(rent.getRentalEndTime()).thenReturn(LocalDateTime.of(2023, 1, 1, 1, 0));
         }
 
         @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -15,6 +15,7 @@ import com.klodnicki.Bike.v2.repository.UserRepository;
 import com.klodnicki.Bike.v2.service.api.ChargingStationServiceApi;
 import com.klodnicki.Bike.v2.service.api.UserServiceApi;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.modelmapper.ModelMapper;
@@ -223,64 +224,59 @@ class RentBikeServiceHandlerTest {
         // themselves have the correct state.
     }
 
-    @Test
-    public void returnVehicle_ShouldAddReturnedBikeToStation_WhenGivenBikeObject() {
-        //Arrange
-        List<Bike> bikeList = new ArrayList<>();
+    @Nested
+    class nestedTestsForReturnVehicleMethods {
 
-        Rent rent = mock(Rent.class);
-        User user = mock(User.class);
-        Bike bike = mock(Bike.class);
+        private ChargingStation chargingStation;
+        private Rent rent;
+        private User user;
+        private Bike bike;
+        private List<Bike> bikeList;
 
-        ChargingStation chargingStation = new ChargingStation(); //I cannot have here mock(ChargingStation.class) because
-        //I test behaviour of this object, and later I would not able to set a bikeList to it.
-        chargingStation.setId(1L);
+        @BeforeEach
+        public void setUpForRentMethod() {
+            bikeList = new ArrayList<>();
 
-        bikeList.add(bike);
-        chargingStation.setBikeList(bikeList);
+            rent = mock(Rent.class);
+            user = mock(User.class);
+            bike = mock(Bike.class);
+            chargingStation = new ChargingStation();
+            chargingStation.setId(1L);
+            chargingStation.setBikeList(bikeList);
 
-        when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
-        when(rent.getBike()).thenReturn(bike); //I should create mocks so that I don't have to set up these instances,
-        // Mockito will return the mock objects, and then I can define their behaviour by thenReturn
-        when(rent.getUser()).thenReturn(user);
-        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
-        when(rent.getRentalStartTime()).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));
-        when(rent.getRentalEndTime()).thenReturn( LocalDateTime.of(2023, 1, 1, 1, 0));
+            when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
+            when(rent.getBike()).thenReturn(bike); //I should create mocks so that I don't have to set up these instances,
+            // Mockito will return the mock objects, and then I can define their behaviour by thenReturn
+            when(rent.getUser()).thenReturn(user);
+            when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
+            when(rent.getRentalStartTime()).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));
+            when(rent.getRentalEndTime()).thenReturn( LocalDateTime.of(2023, 1, 1, 1, 0));
+        }
 
-        //Act
-        rentBikeServiceHandler.returnVehicle(rent.getId(), chargingStation.getId());
-        List<Bike> actual = chargingStation.getBikeList();
+        @Test
+        public void returnVehicle_ShouldAddReturnedBikeToStation_WhenGivenBikeObject() {
+            //Arrange
+            bikeList.add(bike);
 
-        //Assert
-        assertIterableEquals(bikeList, actual);
-    }
+            //Act
+            rentBikeServiceHandler.returnVehicle(rent.getId(), chargingStation.getId());
+            List<Bike> actual = chargingStation.getBikeList();
 
-    @Test
-    public void returnVehicle_ShouldDecrementStationFreeSlotsByOne_WhenBikeIsReturned() {
-        //Arrange
-        List<Bike> bikeList = new ArrayList<>();
+            //Assert
+            assertIterableEquals(bikeList, actual);
+        }
 
-        Rent rent = mock(Rent.class);
-        User user = mock(User.class);
-        Bike bike = mock(Bike.class);
-        ChargingStation chargingStation = new ChargingStation();
-        chargingStation.setId(1L);
-        chargingStation.setFreeSlots(1); //should decrement by one
-        chargingStation.setBikeList(bikeList);
+        @Test
+        public void returnVehicle_ShouldDecrementStationFreeSlotsByOne_WhenBikeIsReturned() {
+            //Arrange
+            chargingStation.setFreeSlots(1); //should decrement by one
 
-        when(rentRepository.findById(rent.getId())).thenReturn(Optional.of(rent));
-        when(rent.getBike()).thenReturn(bike); //I should create mocks so that I don't have to set up these instances,
-        // Mockito will return the mock objects, and then I can define their behaviour by thenReturn
-        when(rent.getUser()).thenReturn(user);
-        when(chargingStationRepository.findById(chargingStation.getId())).thenReturn(Optional.of(chargingStation));
-        when(rent.getRentalStartTime()).thenReturn(LocalDateTime.of(2023, 1, 1, 0, 0));
-        when(rent.getRentalEndTime()).thenReturn( LocalDateTime.of(2023, 1, 1, 1, 0));
+            //Act
+            rentBikeServiceHandler.returnVehicle(rent.getId(), chargingStation.getId());
+            int actual = chargingStation.getFreeSlots();
 
-        //Act
-        rentBikeServiceHandler.returnVehicle(rent.getId(), chargingStation.getId());
-        int actual = chargingStation.getFreeSlots();
-
-        //Assert
-        assertEquals(0, actual);
+            //Assert
+            assertEquals(0, actual);
+        }
     }
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -1,7 +1,9 @@
 package com.klodnicki.Bike.v2.service;
 
+import com.klodnicki.Bike.v2.DTO.bike.BikeForNormalUserResponseDTO;
 import com.klodnicki.Bike.v2.DTO.rent.RentRequestDTO;
 import com.klodnicki.Bike.v2.DTO.rent.RentResponseDTO;
+import com.klodnicki.Bike.v2.model.entity.Bike;
 import com.klodnicki.Bike.v2.model.entity.Rent;
 import com.klodnicki.Bike.v2.repository.BikeRepository;
 import com.klodnicki.Bike.v2.repository.ChargingStationRepository;
@@ -13,9 +15,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -64,5 +69,28 @@ class RentBikeServiceHandlerTest {
 
         //Assert
         assertEquals(expected, actual);
+    }
+
+    @Test
+    public void findAvailableBikes_ShouldReturnListOfBikeForNormalUserResponseDTO_WhenGivenListOfBikes() {
+        //Arrange
+        List<Bike> listOfBikes = new ArrayList<>();
+        List<BikeForNormalUserResponseDTO> expected = new ArrayList<>();
+
+        when(bikeRepository.findByIsRentedFalse()).thenReturn(listOfBikes);
+
+        for (int i = 0; i < 3; i++) {
+            Bike bike = new Bike();
+            bike.setRented(false);
+            listOfBikes.add(bike);
+
+            expected.add(modelMapper.map(bike, BikeForNormalUserResponseDTO.class));
+        }
+
+        //Act
+        List<BikeForNormalUserResponseDTO> actual = rentBikeServiceHandler.findAvailableBikes();
+
+        //Assert
+        assertIterableEquals(expected, actual);
     }
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/RentBikeServiceHandlerTest.java
@@ -161,6 +161,9 @@ class RentBikeServiceHandlerTest {
         public void rent_ShouldRemoveFromBikeList_WhenProvidedBikeObject() {
             //Arrange
             //Act
+            when(bikeServiceHandler.findBikeById(rentRequest.getBikeId())).thenReturn(bike);
+            when(userService.findUserById(rentRequest.getUserId())).thenReturn(user);
+            when(chargingStationService.findStationById(bike.getChargingStation().getId())).thenReturn(chargingStation);
             rentBikeServiceHandler.rent(rentRequest);
             List<Bike> actual = chargingStation.getBikeList();
 

--- a/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
@@ -83,16 +83,17 @@ class UserServiceHandlerTest {
     @Test
     public void findById_ShouldReturnUserForAdminResponseDTO_WhenProvidedId() {
         //Arrange
-        User user = new User();
-        user.setId(1L);
+        User user = mock(User.class);
+        UserForAdminResponseDTO userDTO = new UserForAdminResponseDTO();
+
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
-        UserForAdminResponseDTO expected = modelMapper.map(user, UserForAdminResponseDTO.class);
+        when(modelMapper.map(user, UserForAdminResponseDTO.class)).thenReturn(userDTO);
 
         //Act
-        UserForAdminResponseDTO actual = userServiceHandler.findById(1L);
+        UserForAdminResponseDTO actual = userServiceHandler.findById(user.getId());
 
         //Assert
-        assertEquals(expected, actual);
+        assertEquals(userDTO, actual);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
@@ -71,8 +71,10 @@ class UserServiceHandlerTest {
 
     private List<UserForAdminResponseDTO> mapUsersToDTO(Iterable<User> users) {
         List<UserForAdminResponseDTO> userDTOs = new ArrayList<>();
+        UserForAdminResponseDTO userDTO = new UserForAdminResponseDTO();
+
         for (User user : users) {
-            UserForAdminResponseDTO userDTO = modelMapper.map(user, UserForAdminResponseDTO.class);
+            when(modelMapper.map(user, UserForAdminResponseDTO.class)).thenReturn(userDTO);
             userDTOs.add(userDTO);
         }
         return userDTOs;

--- a/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
@@ -116,10 +116,11 @@ class UserServiceHandlerTest {
     @Test
     public void banUser_ShouldReturnResponseEntityWithCodeOK_WhenProvidedId() {
         //Arrange
-        User user = new User();
+        User user = mock(User.class);
         user.setId(1L);
         user.setAccountValid(false);
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
 
         //Act
         ResponseEntity<?> response = userServiceHandler.banUser(user.getId());

--- a/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
@@ -99,13 +99,13 @@ class UserServiceHandlerTest {
     @Test
     public void deleteById_ShouldCallOnUserRepositoryExactlyOnce_WhenProvidedId() {
         // Arrange
-        Long id = 1L;
+        User user = mock(User.class);
 
         // Act
-        userServiceHandler.deleteById(id);
+        userServiceHandler.deleteById(user.getId());
 
         // Assert
-        verify(userRepository, times(1)).deleteById(id);
+        verify(userRepository, times(1)).deleteById(user.getId());
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
@@ -34,16 +34,16 @@ class UserServiceHandlerTest {
     @Test
     public void add_ShouldReturnUserForAdminResponseDTO_WhenUserProvided() {
         //Arrange
-        User user = new User();
-        when(userRepository.save(user)).thenReturn(new User());
-
-        UserForAdminResponseDTO expected = modelMapper.map(user, UserForAdminResponseDTO.class);
+        User user = mock(User.class);
+        UserForAdminResponseDTO userDTO = new UserForAdminResponseDTO();
+        when(userRepository.save(user)).thenReturn(user);
+        when(modelMapper.map(user, UserForAdminResponseDTO.class)).thenReturn(userDTO);
 
         //Act
         UserForAdminResponseDTO actual = userServiceHandler.add(user);
 
         //Assert
-        assertEquals(expected, actual);
+        assertEquals(userDTO, actual);
     }
 
     @Test

--- a/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
@@ -20,14 +20,14 @@ import static org.mockito.Mockito.*;
 
 class UserServiceHandlerTest {
 
-    private UserRepository userRepository; // to jest mock
+    private UserRepository userRepository;
     private UserServiceHandler userServiceHandler;
     private ModelMapper modelMapper;
 
     @BeforeEach
     public void setUp() {
         userRepository = mock(UserRepository.class);
-        modelMapper = new ModelMapper();
+        modelMapper = mock(ModelMapper.class);
         userServiceHandler = new UserServiceHandler(userRepository, modelMapper);
     }
 

--- a/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
@@ -132,7 +132,8 @@ class UserServiceHandlerTest {
     @Test
     public void save_ShouldCallOnUserRepositoryExactlyOnce_WhenProvidedUser() {
         //Arrange
-        User user = new User();
+        User user = mock(User.class);
+        when(userRepository.save(user)).thenReturn(user);
 
         //Act
         userServiceHandler.save(user);
@@ -140,6 +141,4 @@ class UserServiceHandlerTest {
         //Assert
         verify(userRepository, times(1)).save(user);
     }
-
-
 }

--- a/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
+++ b/src/test/java/com/klodnicki/Bike/v2/service/UserServiceHandlerTest.java
@@ -24,17 +24,20 @@ class UserServiceHandlerTest {
     private UserServiceHandler userServiceHandler;
     private ModelMapper modelMapper;
 
+    private User user;
+
     @BeforeEach
     public void setUp() {
         userRepository = mock(UserRepository.class);
         modelMapper = mock(ModelMapper.class);
         userServiceHandler = new UserServiceHandler(userRepository, modelMapper);
+
+        user = mock(User.class);
     }
 
     @Test
     public void add_ShouldReturnUserForAdminResponseDTO_WhenUserProvided() {
         //Arrange
-        User user = mock(User.class);
         UserForAdminResponseDTO userDTO = new UserForAdminResponseDTO();
         when(userRepository.save(user)).thenReturn(user);
         when(modelMapper.map(user, UserForAdminResponseDTO.class)).thenReturn(userDTO);
@@ -83,7 +86,6 @@ class UserServiceHandlerTest {
     @Test
     public void findById_ShouldReturnUserForAdminResponseDTO_WhenProvidedId() {
         //Arrange
-        User user = mock(User.class);
         UserForAdminResponseDTO userDTO = new UserForAdminResponseDTO();
 
         when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
@@ -99,8 +101,6 @@ class UserServiceHandlerTest {
     @Test
     public void deleteById_ShouldCallOnUserRepositoryExactlyOnce_WhenProvidedId() {
         // Arrange
-        User user = mock(User.class);
-
         // Act
         userServiceHandler.deleteById(user.getId());
 
@@ -132,7 +132,6 @@ class UserServiceHandlerTest {
     @Test
     public void save_ShouldCallOnUserRepositoryExactlyOnce_WhenProvidedUser() {
         //Arrange
-        User user = mock(User.class);
         when(userRepository.save(user)).thenReturn(user);
 
         //Act


### PR DESCRIPTION
#### Issue
Fix of mocks

### Description
This branch fixes mocking in all `Junit` test classes.

### Motivation
It is more readable to have clear `Junit` tests with mocks and not the "mixture" as it was before (some of them were mocked other not). The reason why it was like that -> I was learning mocking in-between.

### Changes introduced by this pull request
- add `@BeforeEach` methods to prepare environment (mocks and `when-thenReturn` logic)
- add `@Nested` classes with tests methods
- add `ArgumentCaptor` for the Rent class to capture Rent object
- refactor of all `Junit` methods in all test classes

### Testing
- [x] all tests work just fine!!