### PR TITLE
Fix/integration/admin bike controller/clear database

### DIFF
--- a/src/integration_test/java/com/klodnicki/Bike/v2/rest/controller/AdminBikeControllerIntegrationTest.java
+++ b/src/integration_test/java/com/klodnicki/Bike/v2/rest/controller/AdminBikeControllerIntegrationTest.java
@@ -13,6 +13,7 @@ import com.klodnicki.Bike.v2.model.entity.User;
 import com.klodnicki.Bike.v2.repository.BikeRepository;
 import com.klodnicki.Bike.v2.repository.ChargingStationRepository;
 import com.klodnicki.Bike.v2.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.modelmapper.ModelMapper;
@@ -48,8 +49,13 @@ class AdminBikeControllerIntegrationTest {
         chargingStationRepository.save(chargingStation);
         bike = new Bike(null, BikeType.ELECTRIC, null, null, chargingStation);
         bikeRepository.save(bike);
+    }
 
-
+    @AfterEach
+    void clearDatabase() {
+        bikeRepository.deleteAll();
+        chargingStationRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test

--- a/src/integration_test/java/com/klodnicki/Bike/v2/rest/controller/AdminBikeControllerIntegrationTest.java
+++ b/src/integration_test/java/com/klodnicki/Bike/v2/rest/controller/AdminBikeControllerIntegrationTest.java
@@ -54,9 +54,6 @@ class AdminBikeControllerIntegrationTest {
 
     @Test
     void addBike_ShouldAddBikeToDatabaseAndReturnBikeForAdminResponseDTO_WhenBikeRequestDTOIsProvided() {
-        //I must create chargingStation and save it in repo, otherwise I get InvalidDataAccessApiUsageException:
-        // org.hibernate.TransientPropertyValueException: object references an unsaved transient instance -
-        // save the transient instance before flushing
         StationForAdminResponseDTO stationDTO = modelMapper.map(chargingStation, StationForAdminResponseDTO.class);
 
         BikeRequestDTO bikeRequestDTO = new BikeRequestDTO(1L, "test serialNumber", false,


### PR DESCRIPTION
#### Issue
`Test teardown`

### Description
This small branch adds very important feature which is cleaning the database in`AdminBikeControllerIntegrationTest` class

### Motivation
It is very important to clean database in each class and after each test. Why? For isolation, consistency, performance and debugging. 

### Changes introduced by this pull request
- add `@AfterEach` method to clear database
- delete unneeded comment 

### Testing
- [x] database is clean after each test
- [x] all test methods are functional  
